### PR TITLE
fix: properly set exit_status

### DIFF
--- a/e2e/run_test.sh
+++ b/e2e/run_test.sh
@@ -15,7 +15,7 @@ GREEN='\033[0;32m'
 NC='\033[0m'
 
 if [ $exit_status -ne 0 ]; then
-  $exit_status=1
+  exit_status=1
   echo -e $"\n${RED}TESTING FAILED. Review test logs for details.${NC}\n"
 else
   echo -e $"\n${GREEN}TESTING COMPLETED SUCCESSFULLY${NC}\n"


### PR DESCRIPTION
Resolve issue with `run_tests.sh` script in case of failure:

```
# make test
...
--- FAIL: TestBasicValidateComputeMutationKeysFromCreate (0.13s)
    apply.go:15:
                Error Trace:    apply.go:15
                                                        basic_test.go:110
                Error:          Received unexpected error:
                                FatalError{Underlying: error while running command: exit status 1; ╷
                                │ Error: Failed to query available provider packages
                                │
                                │ Could not retrieve the list of available versions for provider
                                │ terraform.example.com/examplecorp/graphql: could not connect to
                                │ terraform.example.com: Failed to request discovery document: Get
                                │ "https://terraform.example.com/.well-known/terraform.json": dial tcp:
                                │ lookup terraform.example.com on 127.0.0.53:53: no such host
                                ╵
                                }
                Test:           TestBasicValidateComputeMutationKeysFromCreate
FAIL
exit status 1
FAIL    github.com/sullivtr/terraform-provider-graphql/e2e      0.395s
./run_test.sh: line 18: 1=1: command not found

TESTING FAILED. Review test logs for details.

Stopping graphql test server
make: *** [Makefile:5: test] Error 1
signal: terminated
```