### PR TITLE
feat: enable HTTP tracing in debug logging level or higher

### DIFF
--- a/graphql/query_executor.go
+++ b/graphql/query_executor.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -53,6 +55,11 @@ func queryExecute(ctx context.Context, d *schema.ResourceData, m interface{}, qu
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 
 	client := &http.Client{}
+	if logging.IsDebugOrHigher() {
+		log.Printf("[DEBUG] Enabling HTTP requests/responses tracing")
+		client.Transport = logging.NewTransport("GraphQL", http.DefaultTransport)
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
With this change, HTTP requests and responses are traced which eases troubleshooting, e.g.:

```
# TF_LOG=debug terraform apply
...
2021-12-13T16:43:14.129+0100 [INFO]  provider.terraform-provider-graphql: 2021/12/13 16:43:14 [DEBUG] Enabling HTTP requests/responses tracing: timestamp=2021-12-13T16:43:14.129+0100
2021-12-13T16:43:14.129+0100 [INFO]  provider.terraform-provider-graphql: 2021/12/13 16:43:14 [DEBUG] GraphQL API Request Details:
---[ REQUEST ]---------------------------------------
POST /graphql HTTP/1.1
Host: apps.cloudhealthtech.com
User-Agent: Go-http-client/1.1
Content-Length: 151
Accept: application/json; charset=utf-8
Content-Type: application/json; charset=utf-8
Accept-Encoding: gzip

{
 "query": "mutation Login($apiKey: String!) {loginAPI(apiKey: $apiKey) {accessToken}}\n",
 "variables": {
  "apiKey": "******"
 }
}

-----------------------------------------------------: timestamp=2021-12-13T16:43:14.129+0100
2021-12-13T16:43:14.978+0100 [INFO]  provider.terraform-provider-graphql: 2021/12/13 16:43:14 [DEBUG] GraphQL API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization,Strict-Transport-Security
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Expose-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization,Strict-Transport-Security
Cache-Control: no-cache, no-store
Connection: keep-alive
Content-Security-Policy: ****** ;
Content-Type: application/json; charset=utf-8
Date: Mon, 13 Dec 2021 15:43:14 GMT
Etag: W/"******"
Pragma: no-cache
Server: nginx
Strict-Transport-Security: max-age=63072000; includeSubdomains; preload
X-Envoy-Decorator-Operation: nginx.ingress.svc.cluster.local:80/*
X-Envoy-Upstream-Service-Time: 466
X-Frame-Options: DENY
X-Frame-Options: DENY
X-Powered-By: Express

{
 "data": {
  "loginAPI": {
   "accessToken": "******"
  }
 }
}

-----------------------------------------------------: timestamp=2021-12-13T16:43:14.977+0100
...
```


Note: this is how it's done in several official terraform providers:
- https://github.com/hashicorp/terraform-provider-kubernetes/blob/v2.7.1/kubernetes/provider.go#L365
- https://github.com/hashicorp/terraform-provider-google/blob/master/google/config.go#L445