### PR TITLE
Allow to override default headers in graphql requests

### DIFF
--- a/graphql/query_executor.go
+++ b/graphql/query_executor.go
@@ -46,11 +46,11 @@ func queryExecute(ctx context.Context, d *schema.ResourceData, m interface{}, qu
 		return nil, nil, err
 	}
 
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/json; charset=utf-8")
 	for key, value := range headers {
 		req.Header.Set(key, value.(string))
 	}
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Accept", "application/json; charset=utf-8")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
Thank you for your work.

This small PR allows to override `Content-Type` and `Accept` header. I found one (probably non-compliant) server which require to have exactly `application/json` type, without encoding. After patch it works correctly with:

```hcl

provider "graphql" {
  # Configuration options
  url = "https://api.example.com/v2/graphql"
  headers = {
    "Content-Type"  = "application/json",
    "Authorization" = "Bearer <token>"
  }
}
```
configuration. Before patch override is ignored, so server is not working