### PR TITLE
feat: add support for terraform provider debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,29 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/sullivtr/terraform-provider-graphql/graphql"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: graphql.Provider,
-	})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: graphql.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/sullivtr/graphql", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
This PR adds support for attaching a go debugger like [delve](https://github.com/go-delve/delve) as described in https://www.terraform.io/plugin/sdkv2/debugging#debugger-based-debugging