### PR TITLE
Support non-string computed keys

### DIFF
--- a/graphql/keys.go
+++ b/graphql/keys.go
@@ -33,7 +33,7 @@ func computeMutationVariableKeys(keyMaps map[string]interface{}, responseObject 
 		if err != nil {
 			return nil, err
 		}
-		mvks[k] = key.(string)
+		mvks[k] = fmt.Sprintf("%v", key)
 	}
 	return mvks, nil
 }

--- a/graphql/keys_test.go
+++ b/graphql/keys_test.go
@@ -41,6 +41,21 @@ func TestComputeMutationVariableKeys(t *testing.T) {
 			expectedValues: map[string]interface{}{"id_key": "another"},
 		},
 		{
+			body:           `{"data": {"id": 1}}`,
+			computeKeys:    map[string]interface{}{"id_key": "id"},
+			expectedValues: map[string]interface{}{"id_key": "1"},
+		},
+		{
+			body:           `{"data": {"pi": 3.14159}}`,
+			computeKeys:    map[string]interface{}{"id_key": "pi"},
+			expectedValues: map[string]interface{}{"id_key": "3.14159"},
+		},
+		{
+			body:           `{"data": {"ready": false}}`,
+			computeKeys:    map[string]interface{}{"id_key": "ready"},
+			expectedValues: map[string]interface{}{"id_key": "false"},
+		},
+		{
 			body:             `{"data": {"todos": [{"id": "computed_id"}, {"id": "second_id"}]}}`,
 			computeKeys:      map[string]interface{}{"id_key": "todos[3].id"},
 			expectedErrorMsg: "provided index, 3, out of range for items in object todos with length of 2",


### PR DESCRIPTION
Dealing with an API with return values that are non-string scalars, and I need to be able to consume them as part of this provider. Specifically, an API with an `id` that is getting returned as a number, which is causing this trace:

```
goroutine 14 [running]:
github.com/sullivtr/terraform-provider-graphql/graphql.computeMutationVariableKeys(0xc0001c4200, 0x1762dcf)
	github.com/sullivtr/terraform-provider-graphql/graphql/keys.go:36 +0x18a
github.com/sullivtr/terraform-provider-graphql/graphql.computeMutationVariables({0xc0001c4200, 0x31, 0x200}, 0x1663040)
	github.com/sullivtr/terraform-provider-graphql/graphql/resource_graphql_mutation.go:327 +0x186
github.com/sullivtr/terraform-provider-graphql/graphql.executeCreateHook({0x184c568, 0xc000054ea0}, 0x0, {0x16473e0, 0xc00009ff60})
	github.com/sullivtr/terraform-provider-graphql/graphql/resource_graphql_mutation.go:273 +0x29f
github.com/sullivtr/terraform-provider-graphql/graphql.resourceGraphqlMutationCreate({0x184c568, 0xc000054ea0}, 0xc0005597b8, {0x16473e0, 0xc00009ff60})
	github.com/sullivtr/terraform-provider-graphql/graphql/resource_graphql_mutation.go:128 +0x45
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0000b8380, {0x184c4f8, 0xc0002842c0}, 0x2, {0x16473e0, 0xc00009ff60})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:330 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0000b8380, {0x184c4f8, 0xc0002842c0}, 0xc0003362a0, 0xc00009e700, {0x16473e0, 0xc00009ff60})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:456 +0x871
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0000a6780, {0x184c4f8, 0xc0002842c0}, 0xc000312500)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/grpc_provider.go:955 +0x9aa
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ApplyResourceChange(0xc00009efc0, {0x184c5a0, 0xc0004a6270}, 0x101732b)
	github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:332 +0x6c
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1729e00, 0xc00009efc0}, {0x184c5a0, 0xc0004a6270}, 0xc000054660, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000ce700, {0x1858df0, 0xc00019c480}, 0xc0000b2300, 0xc0004226c0, 0x1ce1c60, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1194 +0xc8f
google.golang.org/grpc.(*Server).handleStream(0xc0000ce700, {0x1858df0, 0xc00019c480}, 0xc0000b2300, 0x0)
	google.golang.org/grpc@v1.32.0/server.go:1517 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.32.0/server.go:859 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.32.0/server.go:857 +0x294

Error: The terraform-provider-graphql_2.5.4 plugin crashed!
```