### PR TITLE
Fix pagination indexing bug

### DIFF
--- a/graphql/query_executor.go
+++ b/graphql/query_executor.go
@@ -139,12 +139,12 @@ func executePaginatedQuery(ctx context.Context, query string, inputVariables map
 	}
 
 	// Merge all responses
-	for i := 1; i < len(allResponses); i++ {
+	for _, resp := range allResponses {
 		// Merge the data from each response
-		finalResponseData = append(finalResponseData, allResponses[i].Data)
+		finalResponseData = append(finalResponseData, resp.Data)
 
 		// Merge any errors
-		finalResponseErrors = append(finalResponseErrors, allResponses[i].Errors...)
+		finalResponseErrors = append(finalResponseErrors, resp.Errors...)
 	}
 
 	finalResponse := GqlQueryResponse{


### PR DESCRIPTION
The pagination logic reads responses from index 1, which results in skipping the first page, since golang arrays are 0-indexed.