### PR TITLE
fix: prevent drift in nested strings that contain <, > or &

### DIFF
--- a/graphql/keys.go
+++ b/graphql/keys.go
@@ -1,12 +1,23 @@
 package graphql
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
 	"strconv"
 	"strings"
 )
+
+func marshalNoEscape(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
 
 func buildResourceKeyArgs(key string) []string {
 	if key == "" {
@@ -101,7 +112,7 @@ func mapQueryResponseInputKey(m interface{}, value, prev string, parentKeys []st
 			var jsonV string
 			// Check if v is a string, and if not, marshal it as a json string for comparison
 			if str, isString := v.(string); !isString {
-				bytes, err := json.Marshal(v)
+				bytes, err := marshalNoEscape(v)
 				if err != nil {
 					return
 				}

--- a/graphql/keys_test.go
+++ b/graphql/keys_test.go
@@ -184,6 +184,32 @@ func TestMapQueryResponseComplex(t *testing.T) {
 
 }
 
+func TestMapQueryResponseHTMLEscapedCharsInNestedObjects(t *testing.T) {
+	// Regression test: values containing <, >, or & that live inside a nested
+	// object must still be locatable. Previously json.Marshal would HTML-escape
+	// the enclosing object, breaking the substring comparison against the raw
+	// input value and producing a null query_response_input_key_map entry.
+	body := `{"data": {"resource": {"config": {"template": "a<b>c&d"}, "tags": ["x<y>z"]}}}`
+	var foo map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &foo); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	cases := []struct {
+		value     string
+		expectKey string
+	}{
+		{value: "a<b>c&d", expectKey: "data.resource.config.template"},
+		{value: "x<y>z", expectKey: "data.resource.tags[0]"},
+	}
+
+	for i, c := range cases {
+		keyOut, ok := mapQueryResponseInputKey(foo, c.value, "", nil)
+		assert.True(t, ok, "test case %d: expected ok=true for value %q", i, c.value)
+		assert.Equal(t, c.expectKey, keyOut, "test case %d", i)
+	}
+}
+
 func TestMapQueryResponseJSONString(t *testing.T) {
 	var foo map[string]interface{}
 	err := json.Unmarshal([]byte(datablob), &foo)

--- a/graphql/resource_graphql_mutation.go
+++ b/graphql/resource_graphql_mutation.go
@@ -207,7 +207,7 @@ func resourceGraphqlRead(ctx context.Context, d *schema.ResourceData, m interfac
 					}
 
 					if _, isString := remoteVal.(string); !isString {
-						bytes, err := json.Marshal(remoteVal)
+						bytes, err := marshalNoEscape(remoteVal)
 						if err != nil {
 							return diag.FromErr(err)
 						}
@@ -331,11 +331,10 @@ func computeMutationVariables(queryResponseBytes []byte, d *schema.ResourceData)
 		// Combine computed read mutation variables with provided input variables
 		rvks := make(map[string]string)
 		for k, v := range readQueryVariables {
-			// rvks[k] = v.(string)
 			if _, ok := v.(string); ok {
 				rvks[k] = v.(string)
 			} else {
-				bytes, err := json.Marshal(v)
+				bytes, err := marshalNoEscape(v)
 				if err != nil {
 					return err
 				}
@@ -355,7 +354,7 @@ func computeMutationVariables(queryResponseBytes []byte, d *schema.ResourceData)
 			if _, ok := v.(string); ok {
 				dvks[k] = v.(string)
 			} else {
-				bytes, err := json.Marshal(v)
+				bytes, err := marshalNoEscape(v)
 				if err != nil {
 					return err
 				}
@@ -374,7 +373,7 @@ func computeMutationVariables(queryResponseBytes []byte, d *schema.ResourceData)
 			if _, ok := v.(string); ok {
 				mvks[k] = v.(string)
 			} else {
-				bytes, err := json.Marshal(v)
+				bytes, err := marshalNoEscape(v)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Replaces the usage of [json.Marshal](https://pkg.go.dev/encoding/json#Marshal) which encodes characters by using HTMLEscape in order to properly detect drift in nested objects with strings that contain <, > or &.